### PR TITLE
TLF-1261, TLF-1695 Prevent address fields prepopulating with collection point

### DIFF
--- a/checkout-ui-custom/src/controller/AddressController.js
+++ b/checkout-ui-custom/src/controller/AddressController.js
@@ -83,24 +83,22 @@ const AddressController = (() => {
   };
 
   const toggleGoogleInput = () => {
-    if (!$('#v-custom-ship-street').val()) {
-      $('.body-order-form #shipping-data .vcustom--vtex-omnishipping-1-x-address > div > form').toggleClass('google');
-      const selector = `.vcustom--vtex-omnishipping-1-x-address__state, .v-custom-ship-info,
+    $('.body-order-form #shipping-data .vcustom--vtex-omnishipping-1-x-address > div > form').toggleClass('google');
+    const selector = `.vcustom--vtex-omnishipping-1-x-address__state, .v-custom-ship-info,
         .btn-go-to-shipping-wrapper`;
-      $(selector).hide();
-      $('.v-custom-ship-street label').text('Add a new delivery address');
-      $('#v-custom-ship-street').attr('placeholder', 'Search for address');
+    $(selector).hide();
+    $('.v-custom-ship-street label').text('Add a new delivery address');
+    $('#v-custom-ship-street').attr('placeholder', 'Search for address');
 
-      $('#v-custom-ship-street').one('change', () => {
-        $('.body-order-form #shipping-data .vcustom--vtex-omnishipping-1-x-address > div > form').toggleClass('google');
-        $(selector).show();
-        $('.v-custom-ship-street label').text('Street address');
-        $('#v-custom-ship-street').attr(
-          'placeholder',
-          'Eg: 234 Brickfield Rd, Salt River, Cape Town, 7501, South Africa'
-        );
-      });
-    }
+    $('#v-custom-ship-street').one('change', () => {
+      $('.body-order-form #shipping-data .vcustom--vtex-omnishipping-1-x-address > div > form').toggleClass('google');
+      $(selector).show();
+      $('.v-custom-ship-street label').text('Street address');
+      $('#v-custom-ship-street').attr(
+        'placeholder',
+        'Eg: 234 Brickfield Rd, Salt River, Cape Town, 7501, South Africa'
+      );
+    });
   };
 
   const runCustomization = () => {

--- a/checkout-ui-custom/src/controller/AddressController.js
+++ b/checkout-ui-custom/src/controller/AddressController.js
@@ -125,7 +125,7 @@ const AddressController = (() => {
 
   $(document).on('click', '#shipping-data .btn-link.vtex-omnishipping-1-x-btnDelivery', () => {
     setTimeout(() => {
-      if (!$('#ship-complement').val()) {
+      if ($('#ship-complement').val() === '') {
         const phoneNumber =
           window.vtexjs.checkout.orderForm?.clientProfileData?.phone ?? $('#client-phone').val() ?? '';
 

--- a/checkout-ui-custom/src/controller/AddressController.js
+++ b/checkout-ui-custom/src/controller/AddressController.js
@@ -128,7 +128,8 @@ const AddressController = (() => {
   $(document).on('click', '#shipping-data .btn-link.vtex-omnishipping-1-x-btnDelivery', () => {
     setTimeout(() => {
       if (!$('#ship-complement').val()) {
-        const phoneNumber = window.vtexjs.checkout.orderForm?.clientProfileData?.phone ?? '';
+        const phoneNumber =
+          window.vtexjs.checkout.orderForm?.clientProfileData?.phone ?? $('#client-phone').val() ?? '';
 
         $('#ship-complement').val(phoneNumber);
       }

--- a/checkout-ui-custom/src/controller/CollectController.js
+++ b/checkout-ui-custom/src/controller/CollectController.js
@@ -122,6 +122,12 @@ const CollectController = (() => {
     } else {
       if ($('input#custom-pickup-complement').val() === '') {
         $('input#custom-pickup-complement').val(phoneNumber);
+
+        window.vtexjs.checkout.getOrderForm().then(function (orderForm) {
+          const { shippingData } = orderForm;
+          shippingData.address.complement = phoneNumber;
+          return vtexjs.checkout.sendAttachment('shippingData', shippingData);
+        });
       }
     }
     prePopulateReceiverName();
@@ -136,6 +142,12 @@ const CollectController = (() => {
 
     if ($('input#pickup-receiver').val() === '') {
       $('input#pickup-receiver').val(receiverName.trim());
+
+      window.vtexjs.checkout.getOrderForm().then(function (orderForm) {
+        const { shippingData } = orderForm;
+        shippingData.address.receiverName = receiverName.trim();
+        return vtexjs.checkout.sendAttachment('shippingData', shippingData);
+      });
     }
   };
 

--- a/checkout-ui-custom/src/controller/CollectController.js
+++ b/checkout-ui-custom/src/controller/CollectController.js
@@ -109,16 +109,33 @@ const CollectController = (() => {
   };
 
   const addCustomPhoneInput = () => {
+    /* Set orderForm value if exists */
+    const phoneNumber = window.vtexjs.checkout.orderForm?.clientProfileData?.phone ?? $('#client-phone').val() ?? '';
+
     if ($('input#custom-pickup-complement').length === 0) {
       $('.btn-go-to-payment-wrapper').before(PickupComplementField);
       setInputPhone();
 
-      /* Set orderForm value if exists */
-      const phoneNumber = window.vtexjs.checkout.orderForm?.clientProfileData?.phone ?? '';
-
       if (phoneNumber) {
         $('input#custom-pickup-complement').val(phoneNumber);
       }
+    } else {
+      if ($('input#custom-pickup-complement').val() === '') {
+        $('input#custom-pickup-complement').val(phoneNumber);
+      }
+    }
+    prePopulateReceiverName();
+  };
+
+  const prePopulateReceiverName = () => {
+    const { firstName, lastName } = window.vtexjs.checkout.orderForm?.clientProfileData;
+    const firstNameInput = $('#client-first-name').val();
+    const lastNameInput = $('#client-last-name').val();
+
+    const receiverName = firstName ? [firstName, lastName].join(' ') : [firstNameInput, lastNameInput].join(' ');
+
+    if ($('input#pickup-receiver').val() === '') {
+      $('input#pickup-receiver').val(receiverName.trim());
     }
   };
 


### PR DESCRIPTION
### What problem is this solving?
- When adding a new a address, having clicked on Collect tab before and looking at a pickup point, the address fields will be prepopulated with the colleciton point's address!
- After user has entered their name and phone number in step 1, they need to enter a receiver name and phone number in address fields. Most often this may be the same person, so duplicate work is asked of customer.

#### How it works
- Update logic top prevent address fields being prepopulated (user is requred to search for an address, which will populate fields correctly).
- Prepopulate the Receiver Name and Receiver Phone number when they are empty.

#### How to test it?

[Workspace](https://tlf1261--thefoschini.myvtex.com/checkout)

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on
TLF-1261

#### How does this PR make you feel? :link:
![]()