### PR TITLE
Use "state" to prevent creating new MutationObersvers..

### DIFF
--- a/checkout-ui-custom/src/controller/FormController.js
+++ b/checkout-ui-custom/src/controller/FormController.js
@@ -7,6 +7,7 @@ import ViewController from './ViewController';
 const FormController = (() => {
   const state = {
     validForm: true,
+    runningObserver: false,
   };
 
   const checkField = (field) => {
@@ -197,9 +198,12 @@ const FormController = (() => {
 
   // INPUT EVENT SUBSCRIPTION
   const runFormObserver = () => {
+    if (state.runningObserver) return;
+
     const elementToObserveChange = document.querySelector('.shipping-container .box-step');
     const observerConfig = { attributes: false, childList: true, characterData: false };
     const observer = new MutationObserver(() => {
+      state.runningObserver = true;
       if (window.location.hash === STEPS.SHIPPING && !$('btn-link vtex-omnishipping-1-x-btnDelivery').length) {
         runCustomization();
       }

--- a/checkout-ui-custom/src/controller/ViewController.js
+++ b/checkout-ui-custom/src/controller/ViewController.js
@@ -20,6 +20,7 @@ const ViewController = (() => {
     showRICAForm: false,
     showTVorRICAMsg: false,
     showMixedProductsMsg: false,
+    runningObserver: false,
   };
 
   const checkCartCategories = () => {
@@ -229,9 +230,12 @@ const ViewController = (() => {
   });
 
   const runViewObserver = () => {
+    if (state.runningObserver) return;
+
     const elementToObserveChange = document.querySelector('.shipping-container .box-step');
     const observerConfig = { attributes: false, childList: true, characterData: false };
     const observer = new MutationObserver(() => {
+      state.runningObserver = true;
       if (window.location.hash === STEPS.SHIPPING && !$('btn-link vtex-omnishipping-1-x-btnDelivery').length) {
         runCustomization();
       }


### PR DESCRIPTION
### What problem is this solving?
Checkout crashing in Delivery, when the user makes many interactions in the Delivery / Collect UI.

#### How it works
Using the "state" object for the three controllers, we check whether the MutationObserver has already started before starting it.

Further development and experimentation needed to determine when the observers can be disconnected. (eg. on clicking through to the Profile or Payments sections...) 

#### How to test it?
Click beteen Deliver and Collect 10+ times.
On the live checkout you will notice lag and if you are impatient, crashing after 5 - 10 switches.

[Workspace](https://bpf451--thefoschini.myvtex.com/)

### Screenshots/Video example usage:

### Related to / Depends on
BPF-451

#### How does this PR make you feel? :link:
![]()