### PR TITLE
Feature/bpf 601 address validation

### DIFF
--- a/checkout-ui-custom/src/partials/Deliver/utils.js
+++ b/checkout-ui-custom/src/partials/Deliver/utils.js
@@ -476,14 +476,22 @@ export const submitDeliveryForm = async (event) => {
   const { address } = window.vtexjs.checkout.orderForm.shippingData;
   const { hasFurniture, hasTVs, hasSimCards } = getSpecialCategories(items);
 
-  // Prevent false positive for invalid selects.
+  // Prevent false positive validation errors for invalid selects.
   $('select').change();
 
   let fullAddress = {};
 
+  const selectedAddressRadio = "[name='selected-address']:checked";
+
+  // Prevent sending without having selected an address.
+  if ($(selectedAddressRadio).length < 1) {
+    $('html, body').animate({ scrollTop: $('#bash--delivery-form').offset().top }, 400);
+    return;
+  }
+
   setDeliveryLoading();
 
-  const dbAddress = await getAddressByName($("[name='selected-address']:checked").val());
+  const dbAddress = await getAddressByName($(selectedAddressRadio).val());
 
   fullAddress = { ...address, ...dbAddress };
 

--- a/checkout-ui-custom/src/partials/Deliver/utils.js
+++ b/checkout-ui-custom/src/partials/Deliver/utils.js
@@ -356,7 +356,7 @@ export const setAddress = (address, options = { validateExtraFields: true }) => 
     if (requiredAddressFields.includes(invalidFields[0])) {
       window.postMessage({
         action: 'setDeliveryView',
-        view: 'address-form',
+        view: 'address-edit',
       });
     }
 
@@ -495,10 +495,10 @@ export const submitDeliveryForm = async (event) => {
 
   fullAddress = { ...address, ...dbAddress };
 
-  const setAddressResponse = await setAddress(fullAddress, { validateExtraFields: false });
-  const { success } = setAddressResponse;
-  if (!success) {
-    console.error('Set address error', { setAddressResponse });
+  // Final check to validate that the selected address has no validation errors.
+  const { success: didSetAddress } = await setAddress(fullAddress, { validateExtraFields: false });
+  if (!didSetAddress) {
+    console.error('Delivery Form - Address Validation error');
     clearLoaders();
     return;
   }

--- a/checkout-ui-custom/src/partials/Deliver/utils.js
+++ b/checkout-ui-custom/src/partials/Deliver/utils.js
@@ -495,6 +495,14 @@ export const submitDeliveryForm = async (event) => {
 
   fullAddress = { ...address, ...dbAddress };
 
+  const setAddressResponse = await setAddress(fullAddress, { validateExtraFields: false });
+  const { success } = setAddressResponse;
+  if (!success) {
+    console.error('Set address error', { setAddressResponse });
+    clearLoaders();
+    return;
+  }
+
   const furnitureData = {};
   const ricaData = {};
   const tvData = {};


### PR DESCRIPTION
### What problem is this solving?
When selected address has bad validation (because it was created without validation), Go To Payment button doesn't work.

#### How it works
On submit, run setAddress again to validate the address, then take the user to the form to fix the errors.

#### How to test it?

[Workspace](https://bpf601--thefoschini.myvtex.com/admin/vtex-checkout-ui-custom/)

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on
BPF-601

#### How does this PR make you feel? :link:
![]()