### PR TITLE
BPF 631 Furniture for Collect bug

### DIFF
--- a/checkout-ui-custom/src/partials/Deliver/utils.js
+++ b/checkout-ui-custom/src/partials/Deliver/utils.js
@@ -304,6 +304,7 @@ export const updateDeliveryFeeDisplay = () => {
 export const customShippingDataIsValid = () => {
   const items = window.vtexjs.checkout.orderForm?.items;
   const { hasTVs, hasSimCards, hasFurniture } = getSpecialCategories(items);
+  const addressType = window.vtexjs.checkout.orderForm.shippingData?.address?.addressType;
 
   let valid = true;
 
@@ -317,7 +318,7 @@ export const customShippingDataIsValid = () => {
     if (!data.idOrPassport || !data.streetAddress || !data.postalCode) valid = false;
   }
 
-  if (hasFurniture) {
+  if (hasFurniture && addressType !== 'search') {
     const data = getOrderFormCustomData(FURNITURE_APP);
     if (!data.buildingType || !data.parkingDistance || !data.deliveryFloor) valid = false;
   }


### PR DESCRIPTION
### What problem is this solving?
User can't checkout with Furniture and Collect at Store.

#### How it works
Remove validation for furniture fields when user wants to checkout with furniture for collection at a DC.

#### How to test it?

[Workspace](https://bpf604--thefoschini.myvtex.com/)

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on
BPF-631

#### How does this PR make you feel? :link:
![]()