### PR TITLE
Feature/bpf 1406 unselected address

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,38 @@ the styles of this application are stored in the app [tfg-custom-checkout](https
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+#### How to Clear Your Address:
+
+Run the following in your console.
+
+```
+vtexjs.checkout.getOrderForm()
+  .then(function(orderForm) {
+    // Create an object with empty address fields
+    var emptyAddress = {
+      addressType: 'residential',
+      receiverName: '',
+      addressId: '',
+      postalCode: '0001',
+      city: '',
+      state: '',
+      country: 'ZAF',
+      street: '',
+      number: '',
+      neighborhood: '',
+      complement: '',
+      reference: '',
+      geoCoordinates: ['','']
+    };
+
+    // Update the shipping data
+    return vtexjs.checkout.sendAttachment('shippingData', { address: emptyAddress });
+  })
+  .done(function(orderForm) {
+    console.log('Address cleared:', orderForm.shippingData);
+  })
+  .fail(function(error) {
+    console.error('Error clearing the address:', error);
+  });
+```

--- a/checkout-ui-custom/src/controller/DeliverController.js
+++ b/checkout-ui-custom/src/controller/DeliverController.js
@@ -272,7 +272,7 @@ const DeliverController = (() => {
   });
 
   // Remove address error when user selects an address.
-  document.on('click', '.bash--radio-option', () => {
+  $(document).on('click', '.bash--radio-option', () => {
     $('#bash-delivery-error-container').html('');
   });
 

--- a/checkout-ui-custom/src/controller/DeliverController.js
+++ b/checkout-ui-custom/src/controller/DeliverController.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable func-names */
 import DeliverContainer from '../partials/Deliver/DeliverContainer';
 import ExtraFieldsContainer from '../partials/Deliver/ExtraFieldsContainer';
@@ -10,7 +11,7 @@ import {
   populateRicaFields,
   populateTVFields,
   setCartClasses,
-  updateDeliveryFeeDisplay
+  updateDeliveryFeeDisplay,
 } from '../partials/Deliver/utils';
 import { AD_TYPE, STEPS } from '../utils/const';
 import formatAddressSummary from '../utils/formatAddressSummary';
@@ -19,7 +20,7 @@ import {
   getSpecialCategories,
   hideBusinessName,
   scrollToInvalidField,
-  showBusinessName
+  showBusinessName,
 } from '../utils/functions';
 import { preparePhoneField } from '../utils/phoneFields';
 import sendEvent from '../utils/sendEvent';
@@ -71,7 +72,7 @@ const DeliverController = (() => {
       DeliverContainer({
         hasFurnOnly: state.hasFurnOnly,
         hasFurnMixed: state.hasFurnMixed,
-      }),
+      })
     );
 
     if (state.hasFurn) {
@@ -87,7 +88,7 @@ const DeliverController = (() => {
         ExtraFieldsContainer({
           hasSim: state.hasSim,
           hasTV: state.hasTVs,
-        }),
+        })
       );
 
       if (state.hasSim) populateRicaFields();
@@ -155,8 +156,9 @@ const DeliverController = (() => {
       if (errors) populateDeliveryError(errors);
     }
 
-    if (addressType === AD_TYPE.PICKUP // sometimes addressType is undefined ;(
-      || $('#shipping-option-pickup-in-point').hasClass('shp-method-option-active')
+    if (
+      addressType === AD_TYPE.PICKUP || // sometimes addressType is undefined ;(
+      $('#shipping-option-pickup-in-point').hasClass('shp-method-option-active')
     ) {
       // User has Collect enabled, but has Rica or TV products,
       // or Furniture + Non Furn.
@@ -216,13 +218,15 @@ const DeliverController = (() => {
 
     if (!address) return;
 
-    getAddressByName(address.addressName).then((addressByName) => {
-      setAddress(addressByName || address, { validateExtraFields: false });
-      $('input[type="radio"][name="selected-address"]:checked').attr('checked', false);
-      $(this).attr('checked', true);
-    }).catch((e) => {
-      console.error('Could not get address - address selection', e?.message);
-    });
+    getAddressByName(address.addressName)
+      .then((addressByName) => {
+        setAddress(addressByName || address, { validateExtraFields: false });
+        $('input[type="radio"][name="selected-address"]:checked').attr('checked', false);
+        $(this).attr('checked', true);
+      })
+      .catch((e) => {
+        console.error('Could not get address - address selection', e?.message);
+      });
   });
 
   // Rica - show/hide address fields
@@ -267,9 +271,14 @@ const DeliverController = (() => {
     });
   });
 
+  // Remove address error when user selects an address.
+  document.on('click', '.bash--radio-option', () => {
+    $('#bash-delivery-error-container').html('');
+  });
+
   // Invalid fields - remove styling on click, keyup
   $(document).on('keyup click', '.invalid', function () {
-    $(this).removeClass("invalid")
+    $(this).removeClass('invalid');
   });
 
   // Form validation
@@ -304,7 +313,7 @@ const DeliverController = (() => {
 
   return {
     state,
-    init: () => { },
+    init: () => {},
   };
 })();
 export default DeliverController;

--- a/checkout-ui-custom/src/partials/Deliver/DeliveryError.js
+++ b/checkout-ui-custom/src/partials/Deliver/DeliveryError.js
@@ -29,4 +29,12 @@ export const DeliveryError = ({ text, fields }) => {
 `;
 };
 
+export const NoAddressSelectedError = () => ` 
+<div id="bash-delivery-error" class="notification error"  >
+   <div class="notification-content">
+      <p>Select a delivery address.</p>
+   </div>  
+</div>  
+`;
+
 export default DeliveryErrorContainer;

--- a/checkout-ui-custom/src/partials/Deliver/utils.js
+++ b/checkout-ui-custom/src/partials/Deliver/utils.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { PICKUP, RICA_APP, TV_APP } from '../../utils/const';
 import { getSpecialCategories, hideBusinessName, isValidNumberBash, showBusinessName } from '../../utils/functions';
 import isInSouthAfrica from '../../utils/isInSouthAfrica';
@@ -383,10 +384,9 @@ export const populateDeliveryError = (errors = []) => {
   if (errors.length > 0) $('html, body').animate({ scrollTop: $('#bash-delivery-error-container').offset().top }, 400);
 };
 
-export const showAlertBox = () => {
+export const showAlertBox = (alertText = 'Address saved') => {
   $('.alert-container').addClass('show');
   $('.alert-container').slideDown();
-  const alertText = $('[data-view="address-form"]').length > 0 ? 'Address added' : 'Address updated';
   $('#bash-alert-container').html(Alert({ text: alertText }));
   // After 5 seconds, remove the element
   setTimeout(() => {

--- a/checkout-ui-custom/src/utils/submitDeliveryForm.js
+++ b/checkout-ui-custom/src/utils/submitDeliveryForm.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+import { NoAddressSelectedError } from '../partials/Deliver/DeliveryError';
 import { requiredRicaFields, requiredTVFields } from '../partials/Deliver/constants';
 import { setDeliveryLoading } from '../partials/Deliver/utils';
 import { RICA_APP, STEPS, TV_APP } from './const';
@@ -20,7 +22,8 @@ const submitDeliveryForm = async (event) => {
 
   // Prevent sending without having selected an address.
   if ($(selectedAddressRadio).length < 1) {
-    $('html, body').animate({ scrollTop: $('#bash--delivery-form').offset().top }, 400);
+    $('html, body').animate({ scrollTop: $('#bash-delivery-error-container').offset().top }, 400);
+    $('#bash-delivery-error-container').html(NoAddressSelectedError());
     return;
   }
 


### PR DESCRIPTION
### What problem is this solving?
When you do not select an address, and press Go to Payment, you do not necessarily no that you need to select an address.

#### How it works
When no address is selected, in addition to scrolling the user to the right location, show an error message to tell the user what to do.

![image](https://github.com/TFG-Labs/custom-shipping-step-by-items/assets/11704483/68619edf-9603-4c18-94e2-acb1e1588548)

#### How to test it?
[Workspace](https://testing--thefoschini.myvtex.com/checkout/#/payment)

If you had an address already selected use this code in the browser console to clear your address:
```
vtexjs.checkout.getOrderForm()
  .then(function(orderForm) {
    var emptyAddress = {
      addressType: 'residential',
      receiverName: '',
      addressId: '',
      postalCode: '0001',
      city: '',
      state: '',
      country: 'ZAF',
      street: '',
      number: '',
      neighborhood: '',
      complement: '',
      reference: '',
      geoCoordinates: []
    };

    return vtexjs.checkout.sendAttachment('shippingData', { address: emptyAddress });
  })
  .done(function(orderForm) {
    console.log('Address cleared:', orderForm.shippingData);
  })
  .fail(function(error) {
    console.error('Error clearing the address:', error);
  });
```

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on
https://tfginfotec.atlassian.net/browse/BPF-1406

#### How does this PR make you feel? :link:
![]()