### PR TITLE
Fix: Handling Null geoCoordinates on Address in Checkout

### DIFF
--- a/checkout-ui-custom/src/controller/DeliverController.js
+++ b/checkout-ui-custom/src/controller/DeliverController.js
@@ -272,11 +272,12 @@ const DeliverController = (() => {
 
     if (!address) return;
 
+    let selectedAddress;
     getAddressByName(address.addressName)
       .then(async (addressByName) => {
         $('input[type="radio"][name="selected-address"]:checked').attr('checked', false);
         const addressParam = addressByName || address;
-
+        selectedAddress = addressParam;
         const { success: didSetAddress } = await setAddress(addressParam, { track: false });
         if (!didSetAddress) {
           ShowDeliveryError(CouldNotSelectAddressError(addressParam));
@@ -285,6 +286,8 @@ const DeliverController = (() => {
       })
       .catch((e) => {
         console.error('Could not get address - address selection', e?.message);
+        ShowDeliveryError(CouldNotSelectAddressError(selectedAddress));
+        console.error('Select Address - Set Address Failure');
       });
   });
 

--- a/checkout-ui-custom/src/utils/services.js
+++ b/checkout-ui-custom/src/utils/services.js
@@ -26,7 +26,7 @@ const cleanGeoCoordinates = (coOrds) => {
     try {
       coordinates = JSON.parse(coOrds);
     } catch {
-      coordinates = null;
+      coordinates = ['', ''];
     }
     return coordinates;
   }
@@ -167,6 +167,7 @@ export const upsertAddress = async (address) => {
     })
     .then((result) => {
       console.log('Address saved to master data:', result);
+
       return result;
     })
     .catch((error) => {

--- a/checkout-ui-custom/src/utils/setAddress.js
+++ b/checkout-ui-custom/src/utils/setAddress.js
@@ -35,6 +35,12 @@ const setAddress = (address, config) => {
   if (hasTVs) populateExtraFields(address, requiredTVFields, 'tv_');
   if (hasSimCards) populateRicaFields();
 
+  // Fix for null geoCoordinate
+  if (address.geoCoordinate === null) {
+    address.geoCoordinates = ['', ''];
+    console.warn('setAddress - Invalid geoCoordinate, setting default empty value');
+  }
+
   const { isValid, invalidFields } = addressIsValid(address);
 
   if (!isValid) {
@@ -95,7 +101,10 @@ const setAddress = (address, config) => {
       if (address.addressName) updateAddressListing(address);
 
       try {
-        updateDeliveryData({ businessName: address.businessName, receiverPhone: address.receiverPhone });
+        updateDeliveryData({
+          businessName: address.businessName,
+          receiverPhone: address.receiverPhone,
+        });
       } catch (e) {
         sendEvent({
           eventCategory: 'Checkout_SystemError',

--- a/checkout-ui-custom/src/utils/submitDeliveryForm.js
+++ b/checkout-ui-custom/src/utils/submitDeliveryForm.js
@@ -34,15 +34,7 @@ const submitDeliveryForm = async (event) => {
   setDeliveryLoading();
 
   const dbAddress = await getAddressByName($(selectedAddressRadio).val());
-
   fullAddress = { ...address, ...dbAddress };
-
-  // Check for null geoCoordinate and set default value if necessary
-  if (fullAddress.geoCoordinate === null) {
-    fullAddress.geoCoordinate = ['', '']; // update masterdata
-    fullAddress.geoCoordinates = ['', '']; // update shipping data
-    console.warn('submitDeliveryForm - Invalid geoCoordinate, setting default empty value');
-  }
 
   // Final check to validate that the selected address has no validation errors.
   const { success: didSetAddress } = await setAddress(fullAddress, { track: false });

--- a/checkout-ui-custom/src/utils/submitDeliveryForm.js
+++ b/checkout-ui-custom/src/utils/submitDeliveryForm.js
@@ -37,10 +37,8 @@ const submitDeliveryForm = async (event) => {
 
   fullAddress = { ...address, ...dbAddress };
 
-  let shouldPersistMasterData = false;
   // Check for null geoCoordinate and set default value if necessary
   if (fullAddress.geoCoordinate === null) {
-    shouldPersistMasterData = true;
     fullAddress.geoCoordinate = ['', '']; // update masterdata
     fullAddress.geoCoordinates = ['', '']; // update shipping data
     console.warn('submitDeliveryForm - Invalid geoCoordinate, setting default empty value');
@@ -84,7 +82,7 @@ const submitDeliveryForm = async (event) => {
     console.info({ tvDataSent });
   }
 
-  await addOrUpdateAddress(fullAddress, shouldPersistMasterData);
+  await addOrUpdateAddress(fullAddress, false);
 
   // after submitting hide the delivery container
   $('.bash--delivery-container').css('display', 'none');


### PR DESCRIPTION
### What problem is this solving?


This fix addresses an issue where some users are unable to set addresses during checkout due to the geoCoordinates field being null. When the /api/checkout/pub/orderForm/id/attachments/shippingData endpoint receives an address with null geoCoordinates, it returns a 500 error.

Changes:

1. Null Check for geoCoordinates: We now check if geoCoordinates is null and replace it with an empty array ["", ""] to prevent the API from failing.

2. Persisting Updates to Masterdata: On the “Save and Continue” action, if the address had a null geoCoordinates value, we persist the corrected address to the master data. This ensures that addresses with null values are properly updated for future use.

This solution prevents 500 errors during checkout and ensures data consistency for future transactions.


example of address with geoCoordinates of null

<img width="827" alt="Screenshot 2024-09-17 at 07 05 28" src="https://github.com/user-attachments/assets/5f07a2be-b75c-4764-8ddf-ceeb1e0948dc">


example of a corrected address


<img width="862" alt="Screenshot 2024-09-17 at 07 08 24" src="https://github.com/user-attachments/assets/7ad08f6f-f9db-4f65-bab1-027bdede40e2">

also verified on masterdata that updated value reflects

<img width="1126" alt="Screenshot 2024-09-17 at 07 12 03" src="https://github.com/user-attachments/assets/b24b521c-aded-4f91-8a95-a89a986b2d64">



#### How it works

#### How to test it?

[Workspace]()
https://inc256--thefoschini.myvtex.com/
### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on

#### How does this PR make you feel? :link:
![]()