### PR TITLE
fix for coordinate data type

### DIFF
--- a/checkout-ui-custom/src/partials/Deliver/AddAddressManualForm.js
+++ b/checkout-ui-custom/src/partials/Deliver/AddAddressManualForm.js
@@ -236,7 +236,13 @@ export const submitAddAddressManualForm = async (event) => {
   // UPDATE PAYLOAD
   payload.receiverPhone = receiverPhone;
   payload.isDisposable = false;
-  const geoCoords = [parseFloat(payload.lng) || '', parseFloat(payload.lat) || ''];
+
+  let geoCoords = [];
+
+  if (payload.lng && payload.lat) {
+    geoCoords = [parseFloat(payload.lng), parseFloat(payload.lat)];
+  }
+
   payload.geoCoordinate = geoCoords; // for MasterData
   payload.geoCoordinates = geoCoords; // for shippingData
   payload.captureMethod =

--- a/checkout-ui-custom/src/utils/services.js
+++ b/checkout-ui-custom/src/utils/services.js
@@ -26,7 +26,7 @@ const cleanGeoCoordinates = (coOrds) => {
     try {
       coordinates = JSON.parse(coOrds);
     } catch {
-      coordinates = ['', ''];
+      coordinates = [];
     }
     return coordinates;
   }

--- a/checkout-ui-custom/src/utils/setAddress.js
+++ b/checkout-ui-custom/src/utils/setAddress.js
@@ -35,12 +35,6 @@ const setAddress = (address, config) => {
   if (hasTVs) populateExtraFields(address, requiredTVFields, 'tv_');
   if (hasSimCards) populateRicaFields();
 
-  // Fix for null geoCoordinate
-  if (address.geoCoordinate === null) {
-    address.geoCoordinates = ['', ''];
-    console.warn('setAddress - Invalid geoCoordinate, setting default empty value');
-  }
-
   const { isValid, invalidFields } = addressIsValid(address);
 
   if (!isValid) {


### PR DESCRIPTION
### What problem is this solving?


A profile that has an address with coordinates set to ["",""] it throws an error in checkout that they cant proceed to bash pay 

we need to ensure that we sending [] when we dont have coordinates as advised by vtex :

https://bash-za.slack.com/archives/C02BRPLJJPR/p1735025234371859?thread_ts=1734708932.897059&cid=C02BRPLJJPR

confirmed manual capture now sends [] as value of coordinates 

<img width="1352" alt="Screenshot 2024-12-24 at 11 53 37" src="https://github.com/user-attachments/assets/bc61ee12-d663-4f13-b443-0894d87d0e2c" />


<img width="1392" alt="Screenshot 2024-12-24 at 11 56 27" src="https://github.com/user-attachments/assets/ea57f0a4-e486-45e9-b9ba-9202029a60be" />

https://github.com/user-attachments/assets/57e32194-9f77-4fed-9460-0b00a22ac8a6

#### How it works

#### How to test it?

[Workspace]()

### Screenshots/Video example usage:
- Desktop
- Tablet
- Movil

### Related to / Depends on

#### How does this PR make you feel? :link:
![]()



